### PR TITLE
Improve message handling for split IRC messages

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -396,11 +396,20 @@ class Bot:
                     return
 
     def loop_for_messages(self):
+        buffer = ""  # Store partial messages
         while True:
-            received_msgs = self.irc.recv(4096).decode(errors='ignore')
-            for received_msg in received_msgs.split('\r\n'):
-                self.handle_message(received_msg)
+            received_msgs = self.irc.recv(8192).decode(errors='ignore')
+            buffer += received_msgs  # Append new data to buffer
 
+            # Split messages using \r\n
+            messages = buffer.split("\r\n")
+
+            # Check if the last message is incomplete (does not end in \r\n)
+            buffer = messages.pop() if received_msgs[-2:] != "\r\n" else ""
+
+            for received_msg in messages:
+                self.handle_message(received_msg)
+    
     """Private commands"""
 
     def leave(self, message):

--- a/bot.py
+++ b/bot.py
@@ -201,6 +201,17 @@ class Bot:
                 parsed_message['parameters'] = raw_parameters_component
                 raw_parameters_component = raw_parameters_component + " " + parsed_message['tags']['reply-parent-msg-body']
 
+                # Truncate message so it can fit within single message IRC byte limits (assuming its 2048 bytes)
+                encoded = raw_parameters_component.encode('utf-8')
+                if len(encoded) > 1024:
+                    truncated = encoded[:1024]
+                    while truncated:
+                        try:
+                            raw_parameters_component = truncated.decode('utf-8')  # Try decoding
+                            break  
+                        except UnicodeDecodeError:
+                            truncated = truncated[:-1]  # Remove last byte if invalid
+
             if raw_parameters_component and raw_parameters_component[0] == self.prefix:
                 parsed_message['command'] = self.parse_parameters(
                     raw_parameters_component, parsed_message['command'])


### PR DESCRIPTION
The maximum number of characters you can send on Twitch in a single message is 500. But each character can be up to 4 bytes large, which can create a really large message! These really large messages will exceed the IRC size limit. The IRC protocol will break up these large messages into individual ones. Currently, the bot handles messages one at a time. This pulls request will address two things:
1. Add a buffer, so we concatenate messages that were broken up. We merge them before handling message parsing.
2. Reduce the size of parent message for replies. Since this mainly affects message replies, we will shorten the original parent message until it is a safe amount. 

These changes will fix any "unexpected commands" the bot originally experienced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced message handling to automatically truncate overly long messages while preserving valid text encoding.
  - Improved processing by buffering incoming data, ensuring complete messages are correctly captured without loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->