### PR TITLE
Add cast, director, genres and runtime to the Rotten Tomatoes command

### DIFF
--- a/Commands/rottentomatoes.py
+++ b/Commands/rottentomatoes.py
@@ -42,10 +42,14 @@ def rottentomatoes(query, year=None):
     )
 
     target = sorted_results[0]
-    title = target['title']
-    release_year = target['releaseYear']
-    type_ = target['type']
-    vanity = target['vanity']
+    title = target.get('title', 'N/A')
+    release_year = target.get('releaseYear', 'N/A')
+    cast = ", ".join(target.get('castCrew', {}).get('cast', [])[:4]) or "N/A"
+    director = ", ".join(target.get('castCrew', {}).get('crew', {}).get('Director', [])) or "N/A"
+    genres = ", ".join(target.get('genres', [])[:4]) or "N/A"
+    runtime = f"{target['runTime']} min" if target.get('runTime') else "N/A"
+    type_ = target.get('type', 'N/A')
+    vanity = target.get('vanity', 'N/A')
     rotten_tomatoes = target.get('rottenTomatoes', {})
     certified_fresh = rotten_tomatoes.get('certifiedFresh')
     audience_score = rotten_tomatoes.get('audienceScore', "N/A")
@@ -59,8 +63,8 @@ def rottentomatoes(query, year=None):
     rating = "🍅" if certified_fresh else "🗑️" if critics_icon_url and "rotten" in critics_icon_url else "mid "
 
     return f"Rotten Tomatoes scores for {type_.capitalize()} {title} ({release_year}) - Rating: {rating}, \
-          Audience: {audience_score}, Critics: {critics_score}, {url}"
-
+            Audience: {audience_score}, Critics: {critics_score}, 🎬 Director: {director}, 👥 Cast: {cast}, \
+            🏷️ Genres: {genres}, ⏱️ Runtime: {runtime}, {url}"
 
 def reply_with_rottentomatoes(self, message):
     cmd = fetch_cmd_data(self, message)

--- a/Commands/rottentomatoes.py
+++ b/Commands/rottentomatoes.py
@@ -1,97 +1,100 @@
 from Utils.utils import check_cooldown, fetch_cmd_data
-import requests
+import requests, re
 from datetime import datetime
-
 
 APP_ID = "79frdp12pn"
 RESULTS_MAX = 50
-BASE_SEARCH_PARAMS = {
+SEARCH_PARAMS = {
     "x-algolia-api-key": "175588f6e5f8319b27702e4cc4013561",
     "x-algolia-application-id": APP_ID.upper()
 }
+
+
+def _search_rt(query):
+    r = requests.post(
+        f"https://{APP_ID}-1.algolianet.com/1/indexes/*/queries",
+        params=SEARCH_PARAMS,
+        json={"requests": [{"indexName": "content_rt", "params": f"hitsPerPage={RESULTS_MAX}&query={query}"}]}
+    )
+    return r.json()['results'][0]['hits'] if r.ok else None
+
+
+def _format(t):
+    rt = t.get('rottenTomatoes', {})
+    aud = rt.get('audienceScore', 'N/A')
+    crt = rt.get('criticsScore', 'N/A')
+    aud = f"{aud}%" if str(aud).isnumeric() else aud
+    crt = f"{crt}%" if str(crt).isnumeric() else crt
+    icon = rt.get('criticsIconUrl')
+    rating = "🍅" if rt.get('certifiedFresh') else "🗑️" if icon and "rotten" in icon else "ok "
+    tp = t.get('type', 'N/A')
+    path = "m" if tp == "movie" else "tv"
+    cast = ", ".join(t.get('castCrew', {}).get('cast', [])[:4]) or "N/A"
+    director = ", ".join(t.get('castCrew', {}).get('crew', {}).get('Director', [])) or "N/A"
+    genres = ", ".join(t.get('genres', [])[:4]) or "N/A"
+    runtime = f"{t['runTime']} min" if t.get('runTime') else "N/A"
+    url = f"https://www.rottentomatoes.com/{path}/{t.get('vanity', '')}"
+    return (f"Rotten Tomatoes scores for {tp.capitalize()} {t.get('title', 'N/A')} ({t.get('releaseYear', 'N/A')}) "
+            f"- Rating: {rating}, Audience: {aud}, Critics: {crt}, 🎬 Director: {director}, "
+            f"👥 Cast: {cast}, 🏷️ Genres: {genres}, ⏱️ Runtime: {runtime}, {url}")
+
 
 def rottentomatoes(query, year=None):
     if not query:
         return "No query provided!"
 
-    current_year = datetime.now().year
-    if year and year > current_year:
+    if year is not None:
+        if year > datetime.now().year:
+            return "Invalid year provided!"
+        results = _search_rt(query)
+        if not results:
+            return "No results found."
+        return _format(sorted(results, key=lambda x: abs(year - x.get('releaseYear', 0)))[0])
+
+    # Find 4-digit number in query
+    match = re.search(r'\b(\d{4})\b', query)
+    if not match:
+        results = _search_rt(query)
+        if not results:
+            return "No results found."
+        return _format(results[0])
+
+    num = int(match.group(1))
+    results = _search_rt(query)
+
+    # If the number is in a top result's title, use that result
+    for hit in (results or [])[:5]:
+        if str(num) in hit.get('title', ''):
+            return _format(hit)
+
+    # Otherwise treat the number as a year filter
+    if num > datetime.now().year:
         return "Invalid year provided!"
-
-    response = requests.post(
-        f"https://{APP_ID}-1.algolianet.com/1/indexes/*/queries",
-        params=BASE_SEARCH_PARAMS,
-        json={
-            "requests": [{
-                "indexName": "content_rt",
-                "params": f"hitsPerPage={RESULTS_MAX}&query={query}"
-            }]
-        }
-    )
-
-    if not response.ok:
-        return "Could not fetch data from RottenTomatoes! Try again later."
-
-    results = response.json()['results'][0]['hits']
+    stripped = re.sub(r'\s+', ' ', query.replace(match.group(1), '')).strip()
+    results = _search_rt(stripped)
     if not results:
-        return "No results found for the query provided!"
-    
-    sorted_results = sorted(
-        results,
-        key=lambda x: abs(year - x.get('releaseYear', 0)) if year else -x.get('pageViews_popularity', 0)
-    )
+        return "No results found."
+    return _format(sorted(results, key=lambda x: abs(num - x.get('releaseYear', 0)))[0])
 
-    target = sorted_results[0]
-    title = target.get('title', 'N/A')
-    release_year = target.get('releaseYear', 'N/A')
-    cast = ", ".join(target.get('castCrew', {}).get('cast', [])[:4]) or "N/A"
-    director = ", ".join(target.get('castCrew', {}).get('crew', {}).get('Director', [])) or "N/A"
-    genres = ", ".join(target.get('genres', [])[:4]) or "N/A"
-    runtime = f"{target['runTime']} min" if target.get('runTime') else "N/A"
-    type_ = target.get('type', 'N/A')
-    vanity = target.get('vanity', 'N/A')
-    rotten_tomatoes = target.get('rottenTomatoes', {})
-    certified_fresh = rotten_tomatoes.get('certifiedFresh')
-    audience_score = rotten_tomatoes.get('audienceScore', "N/A")
-    audience_score = f"{audience_score}%" if str(audience_score).isnumeric() else audience_score
-    critics_score = rotten_tomatoes.get('criticsScore', "N/A")
-    critics_score = f"{critics_score}%" if str(critics_score).isnumeric() else critics_score
-    critics_icon_url = rotten_tomatoes.get('criticsIconUrl')
-    path = "m" if type_ == "movie" else "tv"
-    url = f"https://www.rottentomatoes.com/{path}/{vanity}"
-
-    rating = "🍅" if certified_fresh else "🗑️" if critics_icon_url and "rotten" in critics_icon_url else "mid "
-
-    return f"Rotten Tomatoes scores for {type_.capitalize()} {title} ({release_year}) - Rating: {rating}, \
-            Audience: {audience_score}, Critics: {critics_score}, 🎬 Director: {director}, 👥 Cast: {cast}, \
-            🏷️ Genres: {genres}, ⏱️ Runtime: {runtime}, {url}"
 
 def reply_with_rottentomatoes(self, message):
     cmd = fetch_cmd_data(self, message)
-
     if not check_cooldown(cmd.state, cmd.nick, cmd.cooldown):
         return
-    
     if not cmd.params:
-        m = f"{cmd.username}, please provide a movie/show name, optionally add year with year:XXXX"
-        self.send_privmsg(cmd.channel, m)
+        self.send_privmsg(cmd.channel, f"{cmd.username}, please provide a movie/show name")
         return
 
     query = cmd.params
-    
-    # Extract year if provided in the format 'year:XXXX'
     year = None
     if 'year:' in query:
-        parts = query.split()
-        for part in parts:
+        for part in query.split():
             if part.startswith('year:'):
                 try:
                     year = int(part.split(':')[1])
-                    query = query.replace(part, '').strip()  # Remove the year part from the query
+                    query = query.replace(part, '').strip()
                 except ValueError:
-                    m = f"{cmd.username}, invalid year format. Please use 'year:XXXX'."
-                    self.send_privmsg(cmd.channel, m)
+                    self.send_privmsg(cmd.channel, f"{cmd.username}, invalid year format. Use 'year:XXXX'.")
                     return
 
-    result = rottentomatoes(query, year)
-    self.send_privmsg(cmd.channel, result)
+    self.send_privmsg(cmd.channel, rottentomatoes(query, year))

--- a/Commands/rottentomatoes.py
+++ b/Commands/rottentomatoes.py
@@ -11,12 +11,16 @@ SEARCH_PARAMS = {
 
 
 def _search_rt(query):
-    r = requests.post(
-        f"https://{APP_ID}-1.algolianet.com/1/indexes/*/queries",
-        params=SEARCH_PARAMS,
-        json={"requests": [{"indexName": "content_rt", "params": f"hitsPerPage={RESULTS_MAX}&query={query}"}]}
-    )
-    return r.json()['results'][0]['hits'] if r.ok else None
+    try:
+        r = requests.post(
+            f"https://{APP_ID}-1.algolianet.com/1/indexes/*/queries",
+            params=SEARCH_PARAMS,
+            json={"requests": [{"indexName": "content_rt", "params": f"hitsPerPage={RESULTS_MAX}&query={query}"}]},
+            timeout=5
+        )
+        return r.json()['results'][0]['hits'] if r.ok else None
+    except requests.RequestException:
+        return None
 
 
 def _format(t):
@@ -27,14 +31,17 @@ def _format(t):
     crt = f"{crt}%" if str(crt).isnumeric() else crt
     icon = rt.get('criticsIconUrl')
     rating = "🍅" if rt.get('certifiedFresh') else "🗑️" if icon and "rotten" in icon else "ok "
-    tp = t.get('type', 'N/A')
+    tp = t.get('type') or 'N/A'
+    tp_str = tp.capitalize()
     path = "m" if tp == "movie" else "tv"
-    cast = ", ".join(t.get('castCrew', {}).get('cast', [])[:4]) or "N/A"
-    director = ", ".join(t.get('castCrew', {}).get('crew', {}).get('Director', [])) or "N/A"
+    cast_crew = t.get('castCrew') or {}
+    crew = cast_crew.get('crew') or {}
+    director = ", ".join(crew.get('Director', [])) or "N/A"
+    cast = ", ".join((cast_crew.get('cast') or [])[:4]) or "N/A"
     genres = ", ".join(t.get('genres', [])[:4]) or "N/A"
     runtime = f"{t['runTime']} min" if t.get('runTime') else "N/A"
-    url = f"https://www.rottentomatoes.com/{path}/{t.get('vanity', '')}"
-    return (f"Rotten Tomatoes scores for {tp.capitalize()} {t.get('title', 'N/A')} ({t.get('releaseYear', 'N/A')}) "
+    url = f"https://www.rottentomatoes.com/{path}/{t.get('vanity') or ''}"
+    return (f"Rotten Tomatoes scores for {tp_str} {t.get('title', 'N/A')} ({t.get('releaseYear', 'N/A')}) "
             f"- Rating: {rating}, Audience: {aud}, Critics: {crt}, 🎬 Director: {director}, "
             f"👥 Cast: {cast}, 🏷️ Genres: {genres}, ⏱️ Runtime: {runtime}, {url}")
 
@@ -49,7 +56,7 @@ def rottentomatoes(query, year=None):
         results = _search_rt(query)
         if not results:
             return "No results found."
-        return _format(sorted(results, key=lambda x: abs(year - x.get('releaseYear', 0)))[0])
+        return _format(sorted(results, key=lambda x: abs(year - int(x.get('releaseYear') or 0)))[0])
 
     # Find 4-digit number in query
     match = re.search(r'\b(\d{4})\b', query)
@@ -74,7 +81,7 @@ def rottentomatoes(query, year=None):
     results = _search_rt(stripped)
     if not results:
         return "No results found."
-    return _format(sorted(results, key=lambda x: abs(num - x.get('releaseYear', 0)))[0])
+    return _format(sorted(results, key=lambda x: abs(num - int(x.get('releaseYear') or 0)))[0])
 
 
 def reply_with_rottentomatoes(self, message):


### PR DESCRIPTION
Extends rottentomatoes.py command to include cast, director, genres, and runtime..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rotten Tomatoes results now show director, cast, genres, runtime, and enhanced rating indicators alongside existing ratings and links.
* **Bug Fixes / Improvements**
  * Smarter handling of year info in queries for more relevant matches and more consistent result selection.
  * Simplified messaging for no-results cases to a single, clear response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->