### PR TITLE
New deadchat.py command

### DIFF
--- a/Commands/deadchat.py
+++ b/Commands/deadchat.py
@@ -3,8 +3,8 @@ from Utils.utils import check_cooldown, fetch_cmd_data, proxy_request
 
 LOGS_API = "https://logs.zonian.dev/channel"
 
-# time span
-SPAN = timedelta(minutes=5)
+# default time span
+DEFAULT_SPAN_MINUTES = 5
 
 # message threshold
 BASELINE = 6
@@ -74,18 +74,18 @@ def _count_messages(messages, start, end, exclude_text):
     return count
 
 
-def _get_window():
+def _get_window(span):
     now = datetime.now(timezone.utc)
-    return {"start": now - SPAN, "end": now}
+    return {"start": now - span, "end": now}
 
 
 def _classify(count):
     return "alive" if count >= BASELINE else "dead"
 
 
-def _get_activity(channel, exclude_text):
+def _get_activity(channel, exclude_text, span):
     try:
-        window = _get_window()
+        window = _get_window(span)
         start = window["start"]
         end = window["end"]
 
@@ -105,7 +105,7 @@ def _get_activity(channel, exclude_text):
 
         return {
             "count": int(count),
-            "minutes": int(SPAN.total_seconds() / 60),
+            "minutes": int(span.total_seconds() / 60),
             "state": _classify(count)
         }
 
@@ -115,12 +115,20 @@ def _get_activity(channel, exclude_text):
 
 def reply_with_message_rate(self, message):
     try:
-        cmd = fetch_cmd_data(self, message)
+        cmd = fetch_cmd_data(self, message, arg_types={ "m": int })
 
         if not check_cooldown(cmd.state, cmd.nick, cmd.cooldown):
             return
 
-        data = _get_activity(cmd.channel, self.prefix)
+        minutes = cmd.args.get("m", DEFAULT_SPAN_MINUTES)
+
+        if not (0 < minutes <= 1440): # 1 day (1440 minutes)
+            self.send_privmsg(cmd.channel, "Minutes must be between 1 and 1440 (1 day).")
+            return
+
+        span = timedelta(minutes=minutes)
+
+        data = _get_activity(cmd.channel, self.prefix, span)
 
         if data is None:
             self.send_privmsg(cmd.channel, "Failed to fetch message data!")
@@ -133,7 +141,7 @@ def reply_with_message_rate(self, message):
         prefix = f"Messages in the past {minutes} minutes: {count}"
 
         if state == "alive":
-            msg = f"{prefix} Alive chat Pog"
+            msg = f"{prefix} alive chat Pog"
         else:
             msg = f"{prefix} deadchatxd"
 

--- a/Commands/deadchat.py
+++ b/Commands/deadchat.py
@@ -9,9 +9,6 @@ SPAN = timedelta(minutes=5)
 # message threshold
 BASELINE = 6
 
-# exclude messages containing command name
-EXCLUDE_TEXT = "<deadchat"
-
 
 def _fetch_messages(channel, date):
     try:
@@ -53,7 +50,7 @@ def _parse_timestamp(ts):
         return None
 
 
-def _count_messages(messages, start, end):
+def _count_messages(messages, start, end, exclude_text):
     count = 0
 
     for msg in messages:
@@ -64,7 +61,7 @@ def _count_messages(messages, start, end):
         if not isinstance(text, str):
             continue
 
-        if EXCLUDE_TEXT in text:
+        if exclude_text in text:
             continue
 
         t = _parse_timestamp(msg.get("timestamp"))
@@ -83,7 +80,7 @@ def _classify(count):
     return "alive" if count >= BASELINE else "dead"
 
 
-def _get_activity(channel):
+def _get_activity(channel, exclude_text):
     try:
         start, end = _get_window()
 
@@ -98,7 +95,7 @@ def _get_activity(channel):
                 return None
             msgs = prev_msgs + msgs
 
-        count = _count_messages(msgs, start, end)
+        count = _count_messages(msgs, start, end, exclude_text)
 
         return {
             "count": int(count),
@@ -117,7 +114,7 @@ def reply_with_message_rate(self, message):
         if not check_cooldown(cmd.state, cmd.nick, cmd.cooldown):
             return
 
-        data = _get_activity(cmd.channel)
+        data = _get_activity(cmd.channel, self.prefix)
 
         if data is None:
             self.send_privmsg(cmd.channel, "Failed to fetch message data!")

--- a/Commands/deadchat.py
+++ b/Commands/deadchat.py
@@ -23,7 +23,10 @@ def _fetch_messages(channel, date):
         r = proxy_request(
             "GET",
             url,
-            params={"jsonBasic": 1}
+            params={
+                "jsonBasic": 1,
+                "rm_only": "true" # makes it faster according to the docs https://logs.zonian.dev/api
+            }
         )
 
         if not r.ok:
@@ -61,7 +64,7 @@ def _count_messages(messages, start, end, exclude_text):
         if not isinstance(text, str):
             continue
 
-        if exclude_text in text:
+        if text.startswith(exclude_text):
             continue
 
         t = _parse_timestamp(msg.get("timestamp"))
@@ -73,7 +76,7 @@ def _count_messages(messages, start, end, exclude_text):
 
 def _get_window():
     now = datetime.now(timezone.utc)
-    return now - SPAN, now
+    return {"start": now - SPAN, "end": now}
 
 
 def _classify(count):
@@ -82,18 +85,21 @@ def _classify(count):
 
 def _get_activity(channel, exclude_text):
     try:
-        start, end = _get_window()
+        window = _get_window()
+        start = window["start"]
+        end = window["end"]
 
         msgs = _fetch_messages(channel, end)
 
         if msgs is None:
             return None
 
+        # handle messages at midnight
         if start.date() != end.date():
-            prev_msgs = _fetch_messages(channel, start)
-            if prev_msgs is None:
+            prev_day_msgs = _fetch_messages(channel, start)
+            if prev_day_msgs is None:
                 return None
-            msgs = prev_msgs + msgs
+            msgs = prev_day_msgs + msgs
 
         count = _count_messages(msgs, start, end, exclude_text)
 

--- a/Commands/deadchat.py
+++ b/Commands/deadchat.py
@@ -1,0 +1,130 @@
+from datetime import datetime, timedelta, timezone
+from Utils.utils import check_cooldown, fetch_cmd_data, proxy_request
+
+LOGS_API = "https://logs.zonian.dev/channel"
+
+# time span
+SPAN = timedelta(minutes=5)
+
+# message threshold
+BASELINE = 6
+
+# exclude messages containing command name
+EXCLUDE_TEXT = "<deadchat"
+
+
+def _fetch_messages(channel, date):
+    try:
+        url = (
+            f"{LOGS_API}/"
+            f"{channel}/"
+            f"{date.year}/"
+            f"{date.month}/"
+            f"{date.day}"
+        )
+
+        r = proxy_request(
+            "GET",
+            url,
+            params={"jsonBasic": 1}
+        )
+
+        if not r.ok:
+            return []
+
+        try:
+            data = r.json()
+        except Exception:
+            return []
+
+        msgs = data.get("messages")
+        return msgs if isinstance(msgs, list) else []
+
+    except Exception:
+        return []
+
+
+def _parse_timestamp(ts):
+    try:
+        if not ts:
+            return None
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _count_messages(messages, start, end):
+    try:
+        count = 0
+
+        for msg in messages:
+            if not isinstance(msg, dict):
+                continue
+
+            text = msg.get("text", "")
+            if EXCLUDE_TEXT in text:
+                continue
+
+            t = _parse_timestamp(msg.get("timestamp"))
+            if t and start <= t < end:
+                count += 1
+
+        return count
+    except Exception:
+        return 0
+
+
+def _get_window():
+    now = datetime.now(timezone.utc)
+    return now - SPAN, now
+
+
+def _classify(count):
+    return "alive" if count >= BASELINE else "dead"
+
+
+def _get_activity(channel):
+    try:
+        start, end = _get_window()
+
+        msgs = _fetch_messages(channel, end)
+        count = _count_messages(msgs, start, end)
+
+        return {
+            "count": int(count),
+            "minutes": int(SPAN.total_seconds() / 60),
+            "state": _classify(count)
+        }
+
+    except Exception:
+        return None
+
+
+def reply_with_message_rate(self, message):
+    try:
+        cmd = fetch_cmd_data(self, message)
+
+        if not check_cooldown(cmd.state, cmd.nick, cmd.cooldown):
+            return
+
+        data = _get_activity(cmd.channel)
+
+        if not data:
+            self.send_privmsg(cmd.channel, "Failed to fetch message data!")
+            return
+
+        count = data["count"]
+        minutes = data["minutes"]
+        state = data["state"]
+
+        prefix = f"Messages in the past {minutes} minutes: {count}"
+
+        if state == "alive":
+            msg = f"{prefix} Alive chat Pog"
+        else:
+            msg = f"{prefix} deadchatxd"
+
+        self.send_privmsg(cmd.channel, msg)
+
+    except Exception:
+        self.send_privmsg(cmd.channel, "An unexpected error occurred while fetching message data.")

--- a/Commands/deadchat.py
+++ b/Commands/deadchat.py
@@ -30,18 +30,18 @@ def _fetch_messages(channel, date):
         )
 
         if not r.ok:
-            return []
+            return None
 
         try:
             data = r.json()
         except Exception:
-            return []
+            return None
 
         msgs = data.get("messages")
-        return msgs if isinstance(msgs, list) else []
+        return msgs if isinstance(msgs, list) else None
 
     except Exception:
-        return []
+        return None
 
 
 def _parse_timestamp(ts):
@@ -54,24 +54,24 @@ def _parse_timestamp(ts):
 
 
 def _count_messages(messages, start, end):
-    try:
-        count = 0
+    count = 0
 
-        for msg in messages:
-            if not isinstance(msg, dict):
-                continue
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
 
-            text = msg.get("text", "")
-            if EXCLUDE_TEXT in text:
-                continue
+        text = msg.get("text", "")
+        if not isinstance(text, str):
+            continue
 
-            t = _parse_timestamp(msg.get("timestamp"))
-            if t and start <= t < end:
-                count += 1
+        if EXCLUDE_TEXT in text:
+            continue
 
-        return count
-    except Exception:
-        return 0
+        t = _parse_timestamp(msg.get("timestamp"))
+        if t and start <= t < end:
+            count += 1
+
+    return count
 
 
 def _get_window():
@@ -88,6 +88,16 @@ def _get_activity(channel):
         start, end = _get_window()
 
         msgs = _fetch_messages(channel, end)
+
+        if msgs is None:
+            return None
+
+        if start.date() != end.date():
+            prev_msgs = _fetch_messages(channel, start)
+            if prev_msgs is None:
+                return None
+            msgs = prev_msgs + msgs
+
         count = _count_messages(msgs, start, end)
 
         return {
@@ -109,7 +119,7 @@ def reply_with_message_rate(self, message):
 
         data = _get_activity(cmd.channel)
 
-        if not data:
+        if data is None:
             self.send_privmsg(cmd.channel, "Failed to fetch message data!")
             return
 

--- a/bot.py
+++ b/bot.py
@@ -90,7 +90,8 @@ class Bot:
             'rrc': rrc.reply_with_random_reddit_comment,
             'gemini3': gemini3.reply_with_grounded_gemini,
             'nba': nba.reply_with_nba_scores,
-            "truth": truth.truthsocial
+            "truth": truth.truthsocial,
+            'deadchat': deadchat.reply_with_message_rate
         }
 
         # only bot owner can use these commands

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,7 @@ from pymongo.mongo_client import MongoClient
 from Commands import (bot_info, date, groq_command, help_ascii, ping, help_chess, source_code, play_chess, ro, r960, help_ro, pyramid, slow_pyramid,
                       news, help_news, daily, roulette, balance, leaderboard, help, shop, timeout, trophies, gemini, gemini2,
                       ascii, reloadglobals, reloadchannel, sparlerlink, suggest, poker, rm, olympics, summarize, describe, rottentomatoes, remind, eight_ball,
-                      guessgame, x, genius, generate_image, rrc, gemini3, nba, truth)
+                      guessgame, x, genius, generate_image, rrc, gemini3, nba, truth, deadchat)
 
 class Bot:
 


### PR DESCRIPTION
This is a new command that checks chat activity over the last 5 minutes using a chatlogs API. 
It labels chat as dead if message count is below 6 messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command to assess channel activity over a configurable rolling window (default span, user-set 1–1440 minutes).
  * Classifies channels as "alive" or "dead" and sends private responses; enforces per-user cooldown.
  * Handles boundary windows spanning midnight to ensure accurate counts.
* **Bug Fixes / Chores**
  * Registered the new command and removed a duplicate command entry in the registry.
* **Reliability**
  * Graceful handling and specific messaging when activity data cannot be retrieved.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BluePigman/BluePagmanBot/pull/131)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->