### PR TITLE
Refactor rottentomatoes.py and update year extraction

### DIFF
--- a/Commands/rottentomatoes.py
+++ b/Commands/rottentomatoes.py
@@ -1,8 +1,15 @@
-from Utils.utils import check_cooldown, fetch_cmd_data
-import requests, re
-from datetime import datetime
+from Utils.utils import (
+    check_cooldown,
+    fetch_cmd_data,
+    proxy_request,
+    log_err
+)
+import re, datetime
+from urllib.parse import quote
 
 APP_ID = "79frdp12pn"
+RT_SEARCH_URL = f"https://{APP_ID}-1.algolianet.com/1/indexes/*/queries"
+
 RESULTS_MAX = 50
 SEARCH_PARAMS = {
     "x-algolia-api-key": "175588f6e5f8319b27702e4cc4013561",
@@ -10,16 +17,51 @@ SEARCH_PARAMS = {
 }
 
 
-def _search_rt(query):
+def _search_rt(query, year=None):
     try:
-        r = requests.post(
-            f"https://{APP_ID}-1.algolianet.com/1/indexes/*/queries",
+        current_year = datetime.datetime.now().year
+
+        if year is not None and not (1888 <= year <= current_year + 15):
+            year = None
+
+        payload = {
+            "requests": [
+                {
+                    "indexName": "content_rt",
+                    "params": f"hitsPerPage={RESULTS_MAX}&query={quote(query)}"
+                }
+            ]
+        }
+
+        response = proxy_request(
+            "POST",
+            RT_SEARCH_URL,
             params=SEARCH_PARAMS,
-            json={"requests": [{"indexName": "content_rt", "params": f"hitsPerPage={RESULTS_MAX}&query={query}"}]},
+            json=payload,
             timeout=5
         )
-        return r.json()['results'][0]['hits'] if r.ok else None
-    except requests.RequestException:
+
+        if not response.ok:
+            return None
+
+        data = response.json()
+        results = data.get("results")
+
+        if not results:
+            return None
+
+        hits = results[0].get("hits") or []
+
+        if year is not None:
+            sorted_hits = sorted(
+                hits,
+                key=lambda x: abs(year - int(x.get("releaseYear") or 0))
+            )
+            return sorted_hits
+
+        return hits
+
+    except Exception:
         return None
 
 
@@ -27,81 +69,84 @@ def _format(t):
     rt = t.get('rottenTomatoes', {})
     aud = rt.get('audienceScore', 'N/A')
     crt = rt.get('criticsScore', 'N/A')
+
     aud = f"{aud}%" if str(aud).isnumeric() else aud
     crt = f"{crt}%" if str(crt).isnumeric() else crt
+
     icon = rt.get('criticsIconUrl')
     rating = "🍅" if rt.get('certifiedFresh') else "🗑️" if icon and "rotten" in icon else "ok "
-    tp = t.get('type') or 'N/A'
-    tp_str = tp.capitalize()
-    path = "m" if tp == "movie" else "tv"
+
+    media_type = t.get('type') or 'N/A'
+    type_str = media_type.capitalize()
+    path = "m" if media_type == "movie" else "tv"
+
     cast_crew = t.get('castCrew') or {}
     crew = cast_crew.get('crew') or {}
+
     director = ", ".join(crew.get('Director', [])) or "N/A"
     cast = ", ".join((cast_crew.get('cast') or [])[:4]) or "N/A"
     genres = ", ".join(t.get('genres', [])[:4]) or "N/A"
     runtime = f"{t['runTime']} min" if t.get('runTime') else "N/A"
+
     url = f"https://www.rottentomatoes.com/{path}/{t.get('vanity') or ''}"
-    return (f"Rotten Tomatoes scores for {tp_str} {t.get('title', 'N/A')} ({t.get('releaseYear', 'N/A')}) "
-            f"- Rating: {rating}, Audience: {aud}, Critics: {crt}, 🎬 Director: {director}, "
-            f"👥 Cast: {cast}, 🏷️ Genres: {genres}, ⏱️ Runtime: {runtime}, {url}")
+
+    return (
+        f"Rotten Tomatoes scores for {type_str} {t.get('title', 'N/A')} ({t.get('releaseYear', 'N/A')}) "
+        f"- Rating: {rating}, Audience: {aud}, Critics: {crt}, 🎬 Director: {director}, "
+        f"👥 Cast: {cast}, 🏷️ Genres: {genres}, ⏱️ Runtime: {runtime}, {url}"
+    )
 
 
-def rottentomatoes(query, year=None):
-    if not query:
-        return "No query provided!"
+def extract_year(query):
+    # matches trailing year formats like:
+    # "Inception 2010"
+    # "Inception (2010)"
+    # "Inception [2010]"
+    match = re.search(r'[\(\[]?(\d{4})[\)\]]?$', query)
 
-    if year is not None:
-        if year > datetime.now().year:
-            return "Invalid year provided!"
-        results = _search_rt(query)
-        if not results:
-            return "No results found."
-        return _format(sorted(results, key=lambda x: abs(year - int(x.get('releaseYear') or 0)))[0])
-
-    # Find 4-digit number in query
-    match = re.search(r'\b(\d{4})\b', query)
     if not match:
-        results = _search_rt(query)
-        if not results:
-            return "No results found."
-        return _format(results[0])
+        return {
+            "cleaned_query": query,
+            "year": None
+        }
 
-    num = int(match.group(1))
-    results = _search_rt(query)
-
-    # If the number is in a top result's title, use that result
-    for hit in (results or [])[:5]:
-        if str(num) in hit.get('title', ''):
-            return _format(hit)
-
-    # Otherwise treat the number as a year filter
-    if num > datetime.now().year:
-        return "Invalid year provided!"
-    stripped = re.sub(r'\s+', ' ', query.replace(match.group(1), '')).strip()
-    results = _search_rt(stripped)
-    if not results:
-        return "No results found."
-    return _format(sorted(results, key=lambda x: abs(num - int(x.get('releaseYear') or 0)))[0])
+    return {
+        "cleaned_query": query[:match.start()].strip(),
+        "year": int(match.group(1))
+    }
 
 
 def reply_with_rottentomatoes(self, message):
-    cmd = fetch_cmd_data(self, message)
-    if not check_cooldown(cmd.state, cmd.nick, cmd.cooldown):
-        return
-    if not cmd.params:
-        self.send_privmsg(cmd.channel, f"{cmd.username}, please provide a movie/show name")
-        return
+    try:
+        cmd = fetch_cmd_data(self, message, arg_types={"year": int}, split_params=True)
 
-    query = cmd.params
-    year = None
-    if 'year:' in query:
-        for part in query.split():
-            if part.startswith('year:'):
-                try:
-                    year = int(part.split(':')[1])
-                    query = query.replace(part, '').strip()
-                except ValueError:
-                    self.send_privmsg(cmd.channel, f"{cmd.username}, invalid year format. Use 'year:XXXX'.")
-                    return
+        if not check_cooldown(cmd.state, cmd.nick, cmd.cooldown):
+            return
 
-    self.send_privmsg(cmd.channel, rottentomatoes(query, year))
+        if not cmd.params:
+            self.send_privmsg(cmd.channel, f"{cmd.username}, please provide a movie/show name")
+            return
+
+        query = " ".join(cmd.params)
+        year = cmd.args.get("year")
+
+        # only search query for the year when -year is not passed and query longer than one word
+        if year is None and len(cmd.params) > 1:
+            extracted = extract_year(query)
+            query = extracted["cleaned_query"]
+            year = extracted["year"]
+
+        hits = _search_rt(query, year=year)
+
+        if not hits:
+            self.send_privmsg(cmd.channel, "No results found.")
+            return
+        
+        first_result = hits[0]
+        formatted_result = _format(first_result)
+
+        self.send_privmsg(cmd.channel, formatted_result)
+
+    except Exception as e:
+        self.send_privmsg(cmd.channel, "Unexpected error occurred.")
+        log_err(e)

--- a/Commands/rottentomatoes.py
+++ b/Commands/rottentomatoes.py
@@ -98,10 +98,7 @@ def _format(t):
 
 
 def extract_year(query):
-    # matches trailing year formats like:
-    # "Inception 2010"
-    # "Inception (2010)"
-    # "Inception [2010]"
+    # matches trailing year formats XXXX, (XXXX), or [XXXX]
     match = re.search(r'[\(\[]?(\d{4})[\)\]]?$', query)
 
     if not match:
@@ -124,13 +121,12 @@ def reply_with_rottentomatoes(self, message):
             return
 
         if not cmd.params:
-            self.send_privmsg(cmd.channel, f"{cmd.username}, please provide a movie/show name")
+            self.send_privmsg(cmd.channel, f"{cmd.username}, please provide a movie/show name.")
             return
 
         query = " ".join(cmd.params)
         year = cmd.args.get("year")
 
-        # only search query for the year when -year is not passed and query longer than one word
         if year is None and len(cmd.params) > 1:
             extracted = extract_year(query)
             query = extracted["cleaned_query"]
@@ -141,11 +137,8 @@ def reply_with_rottentomatoes(self, message):
         if not hits:
             self.send_privmsg(cmd.channel, "No results found.")
             return
-        
-        first_result = hits[0]
-        formatted_result = _format(first_result)
 
-        self.send_privmsg(cmd.channel, formatted_result)
+        self.send_privmsg(cmd.channel, _format(hits[0]))
 
     except Exception as e:
         self.send_privmsg(cmd.channel, "Unexpected error occurred.")


### PR DESCRIPTION
- Refactored `rottentomatoes.py` to use utils functions `proxy_request`, `log_err` and other changes to make the code clearer.

- Script now extracts the year only when:
    - It's at the end of the query, instead of anywhere (optionally surrounded by parenthesis or brackets). 
    - The query is multiple words (I could not find a movie with a title that ends with a year number, only titles with the year itself e.g. 1917).
    - If -year XXXX is not passed as an argument by the user.
    - Year range is from 1888 to current year + 15.

For example, it extracts 2010 from the following patterns:
```
"Inception (2010)"
"Inception (2010"
"Inception 2010)"
"Inception [2010]"
"Inception [2010"
"Inception 2010]"
"Inception 2010"
"Inception -year 2010"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redesigned Rotten Tomatoes lookup flow for more reliable querying and result handling.
  * When a year is provided, results are ranked by closeness to that year; only the top match is shown.
  * Year parsing now accepts trailing formats like "(2010)" or "[2010]" and the year can be passed directly to the command.
  * Broader error handling returns a generic reply on failure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BluePigman/BluePagmanBot/pull/132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->